### PR TITLE
Use env vars for seed credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+CREATOR_EMAIL=creator@example.com
+CREATOR_PASSWORD=secret
+ADMIN_EMAIL=admin@example.com
+ADMIN_PASSWORD=secret
+EMPLOYEE_EMAIL=employee@example.com
+EMPLOYEE_PASSWORD=secret
+CONTACT_EMAIL=contact@example.com

--- a/app/Console/Commands/SetupHRSystem.php
+++ b/app/Console/Commands/SetupHRSystem.php
@@ -46,7 +46,7 @@ class SetupHRSystem extends Command
                 'address' => '123 Avenue des Tests, 75001 Paris',
                 'contact_first_name' => 'Jean',
                 'contact_last_name' => 'Dupont',
-                'contact_email' => 'contact@getsoluce.com',
+                'contact_email' => env('CONTACT_EMAIL'),
                 'contact_phone' => '0123456789',
                 'is_active' => true,
                 'billing_rate' => 50.00,
@@ -57,10 +57,10 @@ class SetupHRSystem extends Command
         // 2. Créer/Mettre à jour le compte créateur
         $this->info('👑 Configuration du compte créateur...');
         $creator = User::updateOrCreate(
-            ['email' => 'ibrahim.sanogo63@gmail.com'],
+            ['email' => env('CREATOR_EMAIL')],
             [
                 'name' => 'Ibrahim Sanogo',
-                'password' => Hash::make('94Valenton@'),
+                'password' => Hash::make(env('CREATOR_PASSWORD')),
                 'role' => 'creator',
                 'enterprise_id' => null,
                 'is_active' => true,
@@ -68,15 +68,15 @@ class SetupHRSystem extends Command
                 'date_of_birth' => '1990-03-15',
             ]
         );
-        $this->line('✅ Créateur : ibrahim.sanogo63@gmail.com / 94Valenton@');
+        $this->line('✅ Créateur : '.env('CREATOR_EMAIL').' / '.env('CREATOR_PASSWORD'));
         
         // 3. Créer/Mettre à jour le compte admin
         $this->info('🏢 Configuration du compte admin...');
         $admin = User::updateOrCreate(
-            ['email' => 'admin@getsoluce.com'],
+            ['email' => env('ADMIN_EMAIL')],
             [
                 'name' => 'Admin Test',
-                'password' => Hash::make('Admin123!'),
+                'password' => Hash::make(env('ADMIN_PASSWORD')),
                 'role' => 'admin',
                 'enterprise_id' => $enterprise->id,
                 'position' => 'Responsable RH',
@@ -89,15 +89,15 @@ class SetupHRSystem extends Command
                 'max_advance_percentage' => 30,
             ]
         );
-        $this->line('✅ Admin : admin@getsoluce.com / Admin123!');
+        $this->line('✅ Admin : '.env('ADMIN_EMAIL').' / '.env('ADMIN_PASSWORD'));
         
         // 4. Créer/Mettre à jour le compte employé
         $this->info('👤 Configuration du compte employé...');
         $employee = User::updateOrCreate(
-            ['email' => 'employee@getsoluce.com'],
+            ['email' => env('EMPLOYEE_EMAIL')],
             [
                 'name' => 'Employé Test',
-                'password' => Hash::make('Employee123!'),
+                'password' => Hash::make(env('EMPLOYEE_PASSWORD')),
                 'role' => 'employee',
                 'enterprise_id' => $enterprise->id,
                 'position' => 'Développeur',
@@ -112,7 +112,7 @@ class SetupHRSystem extends Command
                 'invitation_accepted_at' => now(),
             ]
         );
-        $this->line('✅ Employé : employee@getsoluce.com / Employee123!');
+        $this->line('✅ Employé : '.env('EMPLOYEE_EMAIL').' / '.env('EMPLOYEE_PASSWORD'));
         $this->line('   → Anniversaire aujourd\'hui ! 🎂');
         $this->line('   → Avance disponible : ' . number_format($employee->getMaxAdvanceAmount(), 2) . '€');
         
@@ -162,9 +162,9 @@ class SetupHRSystem extends Command
         $this->table(
             ['Rôle', 'Email', 'Mot de passe', 'Dashboard'],
             [
-                ['👑 Créateur', 'ibrahim.sanogo63@gmail.com', '94Valenton@', 'Vue globale toutes entreprises'],
-                ['🏢 Admin', 'admin@getsoluce.com', 'Admin123!', 'Gestion entreprise + validations'],
-                ['👤 Employé', 'employee@getsoluce.com', 'Employee123!', 'Dashboard personnel + avances'],
+                ['👑 Créateur', env('CREATOR_EMAIL'), env('CREATOR_PASSWORD'), 'Vue globale toutes entreprises'],
+                ['🏢 Admin', env('ADMIN_EMAIL'), env('ADMIN_PASSWORD'), 'Gestion entreprise + validations'],
+                ['👤 Employé', env('EMPLOYEE_EMAIL'), env('EMPLOYEE_PASSWORD'), 'Dashboard personnel + avances'],
             ]
         );
         

--- a/database/seeders/TestAccountsSeeder.php
+++ b/database/seeders/TestAccountsSeeder.php
@@ -16,18 +16,18 @@ class TestAccountsSeeder extends Seeder
     {
         // 1. Créer ou mettre à jour le compte CRÉATEUR
         $creator = User::updateOrCreate(
-            ['email' => 'ibrahim.sanogo63@gmail.com'],
+            ['email' => env('CREATOR_EMAIL')],
             [
                 'name' => 'Ibrahim Sanogo',
-                'password' => Hash::make('94Valenton@'),
+                'password' => Hash::make(env('CREATOR_PASSWORD')),
                 'role' => 'creator',
                 'enterprise_id' => null, // Le créateur n'appartient à aucune entreprise
                 'is_active' => true,
                 'email_verified_at' => now(),
             ]
         );
-        
-        $this->command->info('✅ Compte créateur créé/mis à jour : ibrahim.sanogo63@gmail.com');
+
+        $this->command->info('✅ Compte créateur créé/mis à jour : '.env('CREATOR_EMAIL'));
         
         // 2. Créer une entreprise de test
         $enterprise = Enterprise::firstOrCreate(
@@ -37,7 +37,7 @@ class TestAccountsSeeder extends Seeder
                 'address' => '123 Avenue des Tests, 75001 Paris',
                 'contact_first_name' => 'Jean',
                 'contact_last_name' => 'Dupont',
-                'contact_email' => 'contact@getsoluce.com',
+                'contact_email' => env('CONTACT_EMAIL'),
                 'contact_phone' => '0123456789',
                 'is_active' => true,
                 'billing_rate' => 50.00,
@@ -48,10 +48,10 @@ class TestAccountsSeeder extends Seeder
         
         // 3. Créer ou mettre à jour le compte ADMIN
         $admin = User::updateOrCreate(
-            ['email' => 'admin@getsoluce.com'],
+            ['email' => env('ADMIN_EMAIL')],
             [
                 'name' => 'Admin Test',
-                'password' => Hash::make('Admin123!'),
+                'password' => Hash::make(env('ADMIN_PASSWORD')),
                 'role' => 'admin',
                 'enterprise_id' => $enterprise->id,
                 'position' => 'Responsable RH',
@@ -61,14 +61,14 @@ class TestAccountsSeeder extends Seeder
             ]
         );
         
-        $this->command->info('✅ Compte admin créé/mis à jour : admin@getsoluce.com');
+        $this->command->info('✅ Compte admin créé/mis à jour : '.env('ADMIN_EMAIL'));
         
         // 4. Créer ou mettre à jour le compte EMPLOYEE
         $employee = User::updateOrCreate(
-            ['email' => 'employee@getsoluce.com'],
+            ['email' => env('EMPLOYEE_EMAIL')],
             [
                 'name' => 'Employé Test',
-                'password' => Hash::make('Employee123!'),
+                'password' => Hash::make(env('EMPLOYEE_PASSWORD')),
                 'role' => 'employee',
                 'enterprise_id' => $enterprise->id,
                 'position' => 'Développeur',
@@ -83,7 +83,7 @@ class TestAccountsSeeder extends Seeder
             ]
         );
         
-        $this->command->info('✅ Compte employé créé/mis à jour : employee@getsoluce.com');
+        $this->command->info('✅ Compte employé créé/mis à jour : '.env('EMPLOYEE_EMAIL'));
         
         // 5. Créer quelques données de test pour l'employé
         if ($employee->absences()->count() === 0) {
@@ -113,9 +113,9 @@ class TestAccountsSeeder extends Seeder
         $this->command->table(
             ['Rôle', 'Email', 'Mot de passe'],
             [
-                ['Créateur', 'ibrahim.sanogo63@gmail.com', '94Valenton@'],
-                ['Admin', 'admin@getsoluce.com', 'Admin123!'],
-                ['Employé', 'employee@getsoluce.com', 'Employee123!'],
+                ['Créateur', env('CREATOR_EMAIL'), env('CREATOR_PASSWORD')],
+                ['Admin', env('ADMIN_EMAIL'), env('ADMIN_PASSWORD')],
+                ['Employé', env('EMPLOYEE_EMAIL'), env('EMPLOYEE_PASSWORD')],
             ]
         );
         $this->command->info('');

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -13,8 +13,8 @@ class UserSeeder extends Seeder
     {
         User::create([
             'name'     => 'Admin RH',
-            'email'    => 'admin@acme.local',
-            'password' => Hash::make('password'),
+            'email'    => env('ADMIN_EMAIL'),
+            'password' => Hash::make(env('ADMIN_PASSWORD')),
             'is_admin' => true,
         ]);
     }


### PR DESCRIPTION
## Summary
- store email/password placeholders in `.env.example`
- read seed emails and passwords from env vars

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867ca7c96f0832da928598a22f875f8