### PR TITLE
Add missing seeders for HR modules

### DIFF
--- a/database/seeders/AvanceSeeder.php
+++ b/database/seeders/AvanceSeeder.php
@@ -1,0 +1,22 @@
+<?php
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Avance;
+use App\Models\User;
+
+class AvanceSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $user = User::first();
+
+        Avance::create([
+            'user_id'       => $user->id,
+            'montant'       => 500,
+            'date_echeance' => now()->addMonth(),
+            'motif'         => 'Avance sur salaire',
+            'statut'        => 'En attente',
+        ]);
+    }
+}

--- a/database/seeders/CompteSeeder.php
+++ b/database/seeders/CompteSeeder.php
@@ -1,0 +1,21 @@
+<?php
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Compte;
+use App\Models\User;
+
+class CompteSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $user = User::first();
+
+        Compte::create([
+            'user_id'         => $user->id,
+            'libelle'         => 'Compte courant',
+            'montant_initial' => 1000,
+            'solde_restant'   => 1000,
+        ]);
+    }
+}

--- a/database/seeders/CongeSeeder.php
+++ b/database/seeders/CongeSeeder.php
@@ -1,0 +1,24 @@
+<?php
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Conge;
+use App\Models\User;
+
+class CongeSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $user = User::first();
+
+        Conge::create([
+            'user_id'      => $user->id,
+            'date_debut'   => now()->addDays(5),
+            'date_fin'     => now()->addDays(10),
+            'type'         => 'CP',
+            'motif'        => 'Vacances',
+            'justificatif' => null,
+            'statut'       => 'En attente',
+        ]);
+    }
+}

--- a/database/seeders/NoteDeFraisSeeder.php
+++ b/database/seeders/NoteDeFraisSeeder.php
@@ -1,0 +1,23 @@
+<?php
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\NoteDeFrais;
+use App\Models\User;
+
+class NoteDeFraisSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $user = User::first();
+
+        NoteDeFrais::create([
+            'user_id'      => $user->id,
+            'date'         => now()->subDay(),
+            'montant'      => 42.50,
+            'description'  => 'Repas client',
+            'justificatif' => 'exemple.pdf',
+            'statut'       => 'En attente',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add seeders for Congé, NoteDeFrais, Compte and Avance
- keep DatabaseSeeder referencing all seeders

## Testing
- `php --version` *(fails: command not found)*
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867db350e74832d964a6c1f454a6d86