### PR TITLE
Fix User model fillable and relation indentation

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -19,6 +19,7 @@ class User extends Authenticatable
         'salaire_brut',
         'taux_horaire',
         'jours_ouvres',
+        'enterprise_id',
     ];
 
     protected $hidden = [
@@ -56,9 +57,10 @@ class User extends Authenticatable
     {
         return $this->hasMany(Conge::class);
     }
+
     public function enterprise()
-{
-    return $this->belongsTo(Enterprise::class);
-}
+    {
+        return $this->belongsTo(Enterprise::class);
+    }
 
 }


### PR DESCRIPTION
## Summary
- allow assigning `enterprise_id` via mass assignment
- fix indentation of `enterprise()` relation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6867df8be404832da01fb1e180f3c5b1