### PR TITLE
Add role-based middleware and admin controller

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\Enterprise;
+use App\Models\User;
+
+class AdminController extends Controller
+{
+    /**
+     * Display the admin dashboard with some enterprise statistics.
+     */
+    public function index()
+    {
+        $user = auth()->user();
+        $enterprise = $user->enterprise;
+
+        $employeeCount = $enterprise ? $enterprise->employees()->count() : 0;
+        $pendingAbsences = $enterprise
+            ? $enterprise->absences()->where('statut', 'en attente')->count()
+            : 0;
+
+        return view('admin.dashboard', [
+            'enterprise' => $enterprise,
+            'employeeCount' => $employeeCount,
+            'pendingAbsences' => $pendingAbsences,
+        ]);
+    }
+
+    /**
+     * Display a list of all users in the current enterprise.
+     */
+    public function users()
+    {
+        $user = auth()->user();
+        $enterprise = $user->enterprise;
+        $users = $enterprise ? $enterprise->users()->latest()->get() : collect();
+
+        return view('admin.users', compact('users'));
+    }
+
+    /**
+     * Promote an employee to admin role.
+     */
+    public function promote(User $user)
+    {
+        $user->update(['role' => 'admin']);
+
+        return redirect()->route('admin.users')
+            ->with('success', 'Utilisateur promu administrateur.');
+    }
+}

--- a/app/Http/Middleware/AdminOnly.php
+++ b/app/Http/Middleware/AdminOnly.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class AdminOnly
+{
+    /**
+     * Handle an incoming request ensuring the user is an admin.
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $user = $request->user();
+        if ($user && $user->role === 'admin') {
+            return $next($request);
+        }
+
+        abort(403, 'Admins only.');
+    }
+}

--- a/app/Http/Middleware/AdminOrCreator.php
+++ b/app/Http/Middleware/AdminOrCreator.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class AdminOrCreator
+{
+    /**
+     * Handle an incoming request ensuring the user is an admin or a creator.
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $user = $request->user();
+        if ($user && in_array($user->role, ['admin', 'creator'])) {
+            return $next($request);
+        }
+
+        abort(403, 'Admins or creators only.');
+    }
+}

--- a/app/Http/Middleware/CreatorOnly.php
+++ b/app/Http/Middleware/CreatorOnly.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class CreatorOnly
+{
+    /**
+     * Handle an incoming request ensuring the user is a creator.
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $user = $request->user();
+        if ($user && $user->role === 'creator') {
+            return $next($request);
+        }
+
+        abort(403, 'Creators only.');
+    }
+}

--- a/app/Http/Middleware/EmployeeOnly.php
+++ b/app/Http/Middleware/EmployeeOnly.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EmployeeOnly
+{
+    /**
+     * Handle an incoming request ensuring the user is an employee.
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $user = $request->user();
+        if ($user && $user->role === 'employee') {
+            return $next($request);
+        }
+
+        abort(403, 'Employees only.');
+    }
+}


### PR DESCRIPTION
## Summary
- implement an `AdminController` with dashboard/user management actions
- add middleware classes to restrict access based on `User` role

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6867df9ef2dc832da6f80fcccd860632