### PR TITLE
Add default seeders for HR tables

### DIFF
--- a/database/seeders/AvanceSeeder.php
+++ b/database/seeders/AvanceSeeder.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Avance;
+use App\Models\User;
+
+class AvanceSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $user = User::first();
+
+        Avance::create([
+            'user_id'          => $user->id,
+            'jours_travailles' => 10,
+            'montant_brut'     => 10 * 7 * 11.65,
+            'montant_net'      => round(10 * 7 * 11.65 * 0.77, 2),
+            'statut'           => 'validée',
+        ]);
+    }
+}

--- a/database/seeders/CompteSeeder.php
+++ b/database/seeders/CompteSeeder.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Compte;
+use App\Models\User;
+
+class CompteSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $user = User::first();
+
+        Compte::create([
+            'user_id'        => $user->id,
+            'libelle'        => 'Compte courant',
+            'montant_initial'=> 1000,
+            'solde_restant'  => 1000,
+        ]);
+    }
+}

--- a/database/seeders/CongeSeeder.php
+++ b/database/seeders/CongeSeeder.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Conge;
+use App\Models\User;
+
+class CongeSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $user = User::first();
+
+        Conge::create([
+            'user_id'    => $user->id,
+            'date_debut' => now()->addDays(7),
+            'date_fin'   => now()->addDays(14),
+            'type'       => 'CP',
+            'motif'      => 'Vacances annuelles',
+            'justificatif' => null,
+            'statut'     => 'en_attente',
+        ]);
+    }
+}

--- a/database/seeders/NoteDeFraisSeeder.php
+++ b/database/seeders/NoteDeFraisSeeder.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\NoteDeFrais;
+use App\Models\User;
+
+class NoteDeFraisSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $user = User::first();
+
+        NoteDeFrais::create([
+            'user_id'      => $user->id,
+            'date'         => now()->subDays(3),
+            'montant'      => 75.50,
+            'description'  => 'Déjeuner client',
+            'justificatif' => 'justificatifs/dejeuner.pdf',
+            'statut'       => 'en_attente',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- implement missing seeders referenced in `DatabaseSeeder`
- seed default records for conges, notes de frais, comptes and avances

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867e22412b0832db5ff22a9e5ce382d