### PR TITLE
Fix enterprise relation fillable and indentation

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -19,6 +19,7 @@ class User extends Authenticatable
         'salaire_brut',
         'taux_horaire',
         'jours_ouvres',
+        'enterprise_id',
     ];
 
     protected $hidden = [
@@ -57,8 +58,8 @@ class User extends Authenticatable
         return $this->hasMany(Conge::class);
     }
     public function enterprise()
-{
-    return $this->belongsTo(Enterprise::class);
-}
+    {
+        return $this->belongsTo(Enterprise::class);
+    }
 
 }


### PR DESCRIPTION
## Summary
- include `enterprise_id` in mass-assignable fields for the `User` model
- fix indentation of `enterprise()` relation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6867e3951890832d8d1271a5376ba510