### PR TITLE
Add GETSIRARH field-memory API (sites, interventions, media, JWT auth, import & reports)

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -17,10 +17,21 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Check for composer.json
+      id: composer-check
+      run: |
+        if [ -f composer.json ]; then
+          echo "found=true" >> $GITHUB_OUTPUT
+        else
+          echo "found=false" >> $GITHUB_OUTPUT
+        fi
+
     - name: Validate composer.json and composer.lock
+      if: steps.composer-check.outputs.found == 'true'
       run: composer validate --strict
 
     - name: Cache Composer packages
+      if: steps.composer-check.outputs.found == 'true'
       id: composer-cache
       uses: actions/cache@v3
       with:
@@ -30,6 +41,7 @@ jobs:
           ${{ runner.os }}-php-
 
     - name: Install dependencies
+      if: steps.composer-check.outputs.found == 'true'
       run: composer install --prefer-dist --no-progress
 
     # Add a test script to composer.json, for instance: "test": "vendor/bin/phpunit"

--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# getsoluce2
+# Getsirarh

--- a/app/Http/Controllers/Api/AuthController.php
+++ b/app/Http/Controllers/Api/AuthController.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Services\JwtService;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Validation\ValidationException;
+use App\Models\User;
+
+class AuthController extends Controller
+{
+    public function login(Request $request, JwtService $jwtService)
+    {
+        $data = $request->validate([
+            'email' => ['required', 'email'],
+            'password' => ['required', 'string'],
+        ]);
+
+        $user = User::where('email', $data['email'])->first();
+
+        if (!$user || !Hash::check($data['password'], $user->password)) {
+            throw ValidationException::withMessages([
+                'email' => 'Identifiants invalides.',
+            ]);
+        }
+
+        $token = $jwtService->encode($user);
+
+        return response()->json([
+            'token' => $token,
+            'user' => [
+                'id' => $user->id,
+                'name' => $user->name,
+                'email' => $user->email,
+                'role' => $user->role,
+            ],
+        ]);
+    }
+
+    public function me(Request $request)
+    {
+        $user = $request->user();
+
+        return response()->json([
+            'id' => $user->id,
+            'name' => $user->name,
+            'email' => $user->email,
+            'role' => $user->role,
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/InterventionController.php
+++ b/app/Http/Controllers/Api/InterventionController.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Intervention;
+use App\Models\Site;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Http\Request;
+
+class InterventionController extends Controller
+{
+    public function index(Request $request)
+    {
+        $query = Intervention::query()->with(['site', 'user', 'media']);
+
+        if ($request->user()->role !== User::ROLE_MANAGER) {
+            $query->where('user_id', $request->user()->id);
+        }
+
+        if ($request->filled('site_id')) {
+            $query->where('site_id', $request->integer('site_id'));
+        }
+
+        if ($request->filled('user_id')) {
+            $query->where('user_id', $request->integer('user_id'));
+        }
+
+        if ($request->filled('status')) {
+            $query->where('status', $request->string('status'));
+        }
+
+        if ($request->filled('week_start')) {
+            $start = Carbon::parse($request->string('week_start'))->startOfWeek();
+            $end = (clone $start)->endOfWeek();
+            $query->whereBetween('created_at', [$start, $end]);
+        }
+
+        $interventions = $query->latest()->paginate(25);
+
+        return response()->json($interventions);
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'site_id' => ['required', 'exists:sites,id'],
+            'status' => ['required', 'string'],
+            'problem_resolved' => ['nullable', 'boolean'],
+            'unresolved_reason' => ['nullable', 'string', 'max:255'],
+            'comment' => ['nullable', 'string'],
+        ]);
+
+        $site = Site::findOrFail($data['site_id']);
+
+        $intervention = Intervention::create([
+            'site_id' => $site->id,
+            'user_id' => $request->user()->id,
+            'status' => $data['status'],
+            'problem_resolved' => $data['problem_resolved'] ?? false,
+            'unresolved_reason' => $data['unresolved_reason'] ?? null,
+            'comment' => $data['comment'] ?? null,
+        ]);
+
+        $intervention->load(['site', 'user', 'media']);
+
+        return response()->json($intervention, 201);
+    }
+
+    public function show(Intervention $intervention)
+    {
+        $user = request()->user();
+        if ($user->role !== User::ROLE_MANAGER && $intervention->user_id !== $user->id) {
+            return response()->json(['message' => 'Forbidden'], 403);
+        }
+
+        $intervention->load(['site', 'user', 'media']);
+
+        return response()->json($intervention);
+    }
+
+    public function update(Request $request, Intervention $intervention)
+    {
+        $user = $request->user();
+        if ($user->role !== User::ROLE_MANAGER && $intervention->user_id !== $user->id) {
+            return response()->json(['message' => 'Forbidden'], 403);
+        }
+
+        $data = $request->validate([
+            'status' => ['sometimes', 'string'],
+            'problem_resolved' => ['sometimes', 'boolean'],
+            'unresolved_reason' => ['nullable', 'string', 'max:255'],
+            'comment' => ['nullable', 'string'],
+        ]);
+
+        $intervention->fill($data);
+        $intervention->save();
+        $intervention->load(['site', 'user', 'media']);
+
+        return response()->json($intervention);
+    }
+}

--- a/app/Http/Controllers/Api/MediaController.php
+++ b/app/Http/Controllers/Api/MediaController.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Intervention;
+use App\Models\Media;
+use Illuminate\Http\Request;
+use App\Models\User;
+
+class MediaController extends Controller
+{
+    public function store(Request $request, Intervention $intervention)
+    {
+        $request->validate([
+            'file' => ['required', 'file', 'mimes:jpg,jpeg,png,webp'],
+        ]);
+
+        $user = $request->user();
+        if ($user->role !== User::ROLE_MANAGER && $intervention->user_id !== $user->id) {
+            return response()->json(['message' => 'Forbidden'], 403);
+        }
+
+        $path = $request->file('file')->store('interventions', 'public');
+
+        $media = Media::create([
+            'intervention_id' => $intervention->id,
+            'file_path' => $path,
+        ]);
+
+        return response()->json($media, 201);
+    }
+}

--- a/app/Http/Controllers/Api/ReportController.php
+++ b/app/Http/Controllers/Api/ReportController.php
@@ -1,0 +1,190 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Intervention;
+use Carbon\Carbon;
+use Illuminate\Http\Request;
+
+class ReportController extends Controller
+{
+    public function weekly(Request $request)
+    {
+        [$start, $end] = $this->resolveWeekRange($request);
+
+        $interventions = Intervention::with(['site', 'user'])
+            ->whereBetween('created_at', [$start, $end])
+            ->orderBy('created_at')
+            ->get();
+
+        $bySite = $interventions
+            ->groupBy('site_id')
+            ->map(fn ($group) => [
+                'site' => $group->first()->site,
+                'interventions' => $group->values(),
+            ])
+            ->values();
+
+        $byUser = $interventions
+            ->groupBy('user_id')
+            ->map(fn ($group) => [
+                'user' => $group->first()->user,
+                'interventions' => $group->values(),
+            ])
+            ->values();
+
+        return response()->json([
+            'week_start' => $start->toDateString(),
+            'week_end' => $end->toDateString(),
+            'by_site' => $bySite,
+            'by_user' => $byUser,
+            'chronological' => $interventions->values(),
+        ]);
+    }
+
+    public function exportCsv(Request $request)
+    {
+        [$start, $end] = $this->resolveWeekRange($request);
+        $interventions = Intervention::with(['site', 'user'])
+            ->whereBetween('created_at', [$start, $end])
+            ->orderBy('created_at')
+            ->get();
+
+        $filename = sprintf('getsirarh-week-%s.csv', $start->toDateString());
+
+        $callback = function () use ($interventions) {
+            $handle = fopen('php://output', 'w');
+            fputcsv($handle, [
+                'date',
+                'site_number',
+                'site_name',
+                'user',
+                'status',
+                'problem_resolved',
+                'unresolved_reason',
+                'comment',
+            ]);
+
+            foreach ($interventions as $intervention) {
+                fputcsv($handle, [
+                    $intervention->created_at?->toDateTimeString(),
+                    $intervention->site?->site_number,
+                    $intervention->site?->name,
+                    $intervention->user?->name,
+                    $intervention->status,
+                    $intervention->problem_resolved ? 'oui' : 'non',
+                    $intervention->unresolved_reason,
+                    $intervention->comment,
+                ]);
+            }
+
+            fclose($handle);
+        };
+
+        return response()->streamDownload($callback, $filename, [
+            'Content-Type' => 'text/csv; charset=UTF-8',
+        ]);
+    }
+
+    public function exportPdf(Request $request)
+    {
+        [$start, $end] = $this->resolveWeekRange($request);
+        $interventions = Intervention::with(['site', 'user'])
+            ->whereBetween('created_at', [$start, $end])
+            ->orderBy('created_at')
+            ->get();
+
+        $lines = [
+            'GETSIRARH - Rapport hebdomadaire',
+            sprintf('Semaine du %s au %s', $start->toDateString(), $end->toDateString()),
+            ' ',
+        ];
+
+        foreach ($interventions as $intervention) {
+            $lines[] = sprintf(
+                '%s | %s | %s | %s | %s',
+                $intervention->created_at?->format('Y-m-d H:i'),
+                $intervention->site?->site_number ?? '-',
+                $intervention->site?->name ?? '-',
+                $intervention->user?->name ?? '-',
+                $intervention->status
+            );
+            if ($intervention->problem_resolved) {
+                $lines[] = 'Résolu: oui';
+            } else {
+                $lines[] = 'Résolu: non';
+                if ($intervention->unresolved_reason) {
+                    $lines[] = 'Raison: '.$intervention->unresolved_reason;
+                }
+            }
+            if ($intervention->comment) {
+                $lines[] = 'Commentaire: '.$intervention->comment;
+            }
+            $lines[] = ' ';
+        }
+
+        $pdf = $this->buildPdf($lines);
+
+        return response($pdf, 200, [
+            'Content-Type' => 'application/pdf',
+            'Content-Disposition' => 'attachment; filename="getsirarh-week-'.$start->toDateString().'.pdf"',
+        ]);
+    }
+
+    private function resolveWeekRange(Request $request): array
+    {
+        $start = $request->filled('week_start')
+            ? Carbon::parse($request->string('week_start'))
+            : Carbon::now();
+
+        $start = $start->startOfWeek();
+        $end = (clone $start)->endOfWeek();
+
+        return [$start, $end];
+    }
+
+    private function buildPdf(array $lines): string
+    {
+        $escaped = array_map(function ($line) {
+            $line = str_replace('\\', '\\\\', $line);
+            $line = str_replace('(', '\\(', $line);
+            $line = str_replace(')', '\\)', $line);
+            return $line;
+        }, $lines);
+
+        $content = "BT\n/F1 12 Tf\n50 790 Td\n";
+        foreach ($escaped as $line) {
+            $content .= '(' . $line . ") Tj\nT*\n";
+        }
+        $content .= "ET\n";
+
+        $objects = [];
+        $objects[] = "<< /Type /Catalog /Pages 2 0 R >>";
+        $objects[] = "<< /Type /Pages /Kids [3 0 R] /Count 1 >>";
+        $objects[] = "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>";
+        $objects[] = "<< /Length ".strlen($content)." >>\nstream\n".$content."endstream";
+        $objects[] = "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>";
+
+        $pdf = "%PDF-1.4\n";
+        $offsets = [0];
+
+        foreach ($objects as $index => $object) {
+            $offsets[] = strlen($pdf);
+            $pdf .= ($index + 1)." 0 obj\n".$object."\nendobj\n";
+        }
+
+        $xrefPosition = strlen($pdf);
+        $pdf .= "xref\n0 ".(count($objects) + 1)."\n";
+        $pdf .= "0000000000 65535 f \n";
+
+        foreach (array_slice($offsets, 1) as $offset) {
+            $pdf .= sprintf("%010d 00000 n \n", $offset);
+        }
+
+        $pdf .= "trailer\n<< /Size ".(count($objects) + 1)." /Root 1 0 R >>\n";
+        $pdf .= "startxref\n".$xrefPosition."\n%%EOF\n";
+
+        return $pdf;
+    }
+}

--- a/app/Http/Controllers/Api/SiteController.php
+++ b/app/Http/Controllers/Api/SiteController.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Site;
+use App\Services\SpreadsheetImporter;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
+
+class SiteController extends Controller
+{
+    public function index(Request $request)
+    {
+        $query = Site::query();
+
+        if ($request->filled('site_number')) {
+            $query->where('site_number', 'like', '%'.$request->string('site_number').'%');
+        }
+
+        if ($request->filled('filter')) {
+            $filter = $request->string('filter')->toString();
+            if ($filter === 'in_progress') {
+                $query->whereHas('interventions', function ($subQuery) {
+                    $subQuery->whereIn('status', ['en_route', 'sur_place']);
+                });
+            }
+
+            if ($filter === 'pending') {
+                $query->whereHas('interventions', function ($subQuery) {
+                    $subQuery->where('status', 'en_attente');
+                });
+            }
+
+            if ($filter === 'unresolved') {
+                $query->whereHas('interventions', function ($subQuery) {
+                    $subQuery->where('problem_resolved', false);
+                });
+            }
+        }
+
+        $sites = $query
+            ->with(['interventions' => fn ($relation) => $relation->latest()->limit(5)])
+            ->orderBy('site_number')
+            ->paginate(25);
+
+        return response()->json($sites);
+    }
+
+    public function show(Site $site)
+    {
+        $site->load(['interventions.user', 'interventions.media']);
+
+        return response()->json($site);
+    }
+
+    public function import(Request $request, SpreadsheetImporter $importer)
+    {
+        $request->validate([
+            'file' => ['required', 'file'],
+        ]);
+
+        $rows = $importer->fromUploadedFile($request->file('file'));
+        $created = 0;
+        $updated = 0;
+        $errors = [];
+
+        foreach ($rows as $index => $row) {
+            $normalized = [
+                'site_number' => $row['site_number'] ?? $row['numero_site'] ?? $row['num_site'] ?? null,
+                'name' => $row['name'] ?? $row['nom'] ?? null,
+                'address' => $row['address'] ?? $row['adresse'] ?? null,
+                'comment' => $row['comment'] ?? $row['commentaire'] ?? null,
+            ];
+
+            $validator = Validator::make($normalized, [
+                'site_number' => ['required', 'string'],
+                'name' => ['required', 'string'],
+                'address' => ['required', 'string'],
+                'comment' => ['nullable', 'string'],
+            ]);
+
+            if ($validator->fails()) {
+                $errors[] = [
+                    'row' => $index + 2,
+                    'errors' => $validator->errors()->all(),
+                ];
+                continue;
+            }
+
+            $site = Site::updateOrCreate(
+                ['site_number' => $normalized['site_number']],
+                $normalized
+            );
+
+            if ($site->wasRecentlyCreated) {
+                $created++;
+            } else {
+                $updated++;
+            }
+        }
+
+        return response()->json([
+            'created' => $created,
+            'updated' => $updated,
+            'errors' => $errors,
+        ]);
+    }
+}

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -64,5 +64,7 @@ class Kernel extends HttpKernel
         'admin.only' => \App\Http\Middleware\AdminOnly::class,
         'employee.only' => \App\Http\Middleware\EmployeeOnly::class,
         'admin.or.creator' => \App\Http\Middleware\AdminOrCreator::class,
+        'auth.jwt' => \App\Http\Middleware\AuthenticateJwt::class,
+        'role' => \App\Http\Middleware\EnsureRole::class,
     ];
 }

--- a/app/Http/Middleware/AuthenticateJwt.php
+++ b/app/Http/Middleware/AuthenticateJwt.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\User;
+use App\Services\JwtService;
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class AuthenticateJwt
+{
+    public function handle(Request $request, Closure $next)
+    {
+        $header = $request->header('Authorization');
+        if (!$header || !str_starts_with($header, 'Bearer ')) {
+            return response()->json(['message' => 'Unauthorized'], 401);
+        }
+
+        $token = substr($header, 7);
+        $payload = app(JwtService::class)->decode($token);
+
+        if (!$payload || !isset($payload['sub'])) {
+            return response()->json(['message' => 'Unauthorized'], 401);
+        }
+
+        $user = User::find($payload['sub']);
+        if (!$user) {
+            return response()->json(['message' => 'Unauthorized'], 401);
+        }
+
+        Auth::setUser($user);
+        $request->setUserResolver(fn () => $user);
+
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/EnsureRole.php
+++ b/app/Http/Middleware/EnsureRole.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class EnsureRole
+{
+    public function handle(Request $request, Closure $next, ...$roles)
+    {
+        $user = $request->user();
+
+        if (!$user || !in_array($user->role, $roles, true)) {
+            return response()->json(['message' => 'Forbidden'], 403);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Models/Intervention.php
+++ b/app/Models/Intervention.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Intervention extends Model
+{
+    use HasFactory;
+
+    public const STATUS_EN_ROUTE = 'en_route';
+    public const STATUS_SUR_PLACE = 'sur_place';
+    public const STATUS_TERMINE = 'termine';
+    public const STATUS_EN_ATTENTE = 'en_attente';
+
+    protected $fillable = [
+        'site_id',
+        'user_id',
+        'status',
+        'problem_resolved',
+        'unresolved_reason',
+        'comment',
+    ];
+
+    protected $casts = [
+        'problem_resolved' => 'boolean',
+    ];
+
+    public function site()
+    {
+        return $this->belongsTo(Site::class);
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function media()
+    {
+        return $this->hasMany(Media::class);
+    }
+}

--- a/app/Models/Media.php
+++ b/app/Models/Media.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Media extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'intervention_id',
+        'file_path',
+    ];
+
+    public function intervention()
+    {
+        return $this->belongsTo(Intervention::class);
+    }
+}

--- a/app/Models/Site.php
+++ b/app/Models/Site.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Site extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'site_number',
+        'name',
+        'address',
+        'comment',
+    ];
+
+    public function interventions()
+    {
+        return $this->hasMany(Intervention::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -10,11 +10,15 @@ class User extends Authenticatable
 {
     use HasFactory, Notifiable;
 
+    public const ROLE_SALARIE = 'ROLE_SALARIE';
+    public const ROLE_MANAGER = 'ROLE_MANAGER';
+
     protected $fillable = [
         'name',
         'email',
         'password',
         'is_admin',
+        'role',
         'poste',
         'salaire_brut',
         'taux_horaire',
@@ -56,7 +60,12 @@ class User extends Authenticatable
     {
         return $this->hasMany(Conge::class);
     }
-    public function enterprise()
+
+    public function interventions()
+    {
+        return $this->hasMany(Intervention::class);
+    }
+public function enterprise()
 {
     return $this->belongsTo(Enterprise::class);
 }

--- a/app/Services/JwtService.php
+++ b/app/Services/JwtService.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\User;
+
+class JwtService
+{
+    public function encode(User $user): string
+    {
+        $header = ['typ' => 'JWT', 'alg' => 'HS256'];
+        $payload = [
+            'sub' => $user->id,
+            'role' => $user->role,
+            'exp' => time() + (int) config('jwt.ttl'),
+            'iat' => time(),
+        ];
+
+        return $this->buildToken($header, $payload);
+    }
+
+    public function decode(string $token): ?array
+    {
+        $parts = explode('.', $token);
+        if (count($parts) !== 3) {
+            return null;
+        }
+
+        [$encodedHeader, $encodedPayload, $encodedSignature] = $parts;
+        $signature = $this->base64UrlEncode(
+            hash_hmac('sha256', $encodedHeader.'.'.$encodedPayload, $this->secret(), true)
+        );
+
+        if (!hash_equals($signature, $encodedSignature)) {
+            return null;
+        }
+
+        $payload = json_decode($this->base64UrlDecode($encodedPayload), true);
+
+        if (!$payload || (isset($payload['exp']) && $payload['exp'] < time())) {
+            return null;
+        }
+
+        return $payload;
+    }
+
+    private function buildToken(array $header, array $payload): string
+    {
+        $encodedHeader = $this->base64UrlEncode(json_encode($header));
+        $encodedPayload = $this->base64UrlEncode(json_encode($payload));
+        $signature = $this->base64UrlEncode(
+            hash_hmac('sha256', $encodedHeader.'.'.$encodedPayload, $this->secret(), true)
+        );
+
+        return implode('.', [$encodedHeader, $encodedPayload, $signature]);
+    }
+
+    private function base64UrlEncode(string $value): string
+    {
+        return rtrim(strtr(base64_encode($value), '+/', '-_'), '=');
+    }
+
+    private function base64UrlDecode(string $value): string
+    {
+        return base64_decode(strtr($value, '-_', '+/'));
+    }
+
+    private function secret(): string
+    {
+        return (string) config('jwt.secret');
+    }
+}

--- a/app/Services/SpreadsheetImporter.php
+++ b/app/Services/SpreadsheetImporter.php
@@ -1,0 +1,192 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Http\UploadedFile;
+use RuntimeException;
+use ZipArchive;
+
+class SpreadsheetImporter
+{
+    public function fromUploadedFile(UploadedFile $file): array
+    {
+        $extension = strtolower($file->getClientOriginalExtension());
+
+        if ($extension === 'csv') {
+            return $this->fromCsv($file->getPathname());
+        }
+
+        if ($extension === 'xlsx') {
+            return $this->fromXlsx($file->getPathname());
+        }
+
+        throw new RuntimeException('Format de fichier non supporté. Utilisez CSV ou XLSX.');
+    }
+
+    private function fromCsv(string $path): array
+    {
+        $handle = fopen($path, 'r');
+        if (!$handle) {
+            throw new RuntimeException('Impossible de lire le fichier CSV.');
+        }
+
+        $rows = [];
+        $delimiter = $this->detectDelimiter($handle);
+
+        $header = null;
+        while (($data = fgetcsv($handle, 0, $delimiter)) !== false) {
+            if ($header === null) {
+                $header = $this->normalizeHeaderRow($data);
+                continue;
+            }
+
+            if (count(array_filter($data, fn ($value) => $value !== null && $value !== '')) === 0) {
+                continue;
+            }
+
+            $rows[] = $this->mapRow($header, $data);
+        }
+
+        fclose($handle);
+
+        return $rows;
+    }
+
+    private function fromXlsx(string $path): array
+    {
+        $zip = new ZipArchive();
+        if ($zip->open($path) !== true) {
+            throw new RuntimeException('Impossible de lire le fichier XLSX.');
+        }
+
+        $sharedStrings = $this->loadSharedStrings($zip);
+        $sheetXml = $zip->getFromName('xl/worksheets/sheet1.xml');
+        $zip->close();
+
+        if (!$sheetXml) {
+            throw new RuntimeException('Feuille XLSX introuvable.');
+        }
+
+        $xml = simplexml_load_string($sheetXml);
+        if (!$xml || !isset($xml->sheetData)) {
+            throw new RuntimeException('Format XLSX invalide.');
+        }
+
+        $rows = [];
+        $header = null;
+
+        foreach ($xml->sheetData->row as $row) {
+            $rowData = [];
+            foreach ($row->c as $cell) {
+                $reference = (string) $cell['r'];
+                $columnIndex = $this->columnIndexFromReference($reference);
+                $value = (string) $cell->v;
+                if ((string) $cell['t'] === 's') {
+                    $value = $sharedStrings[(int) $value] ?? '';
+                }
+                $rowData[$columnIndex] = $value;
+            }
+
+            ksort($rowData);
+            $rowValues = array_values($rowData);
+
+            if ($header === null) {
+                $header = $this->normalizeHeaderRow($rowValues);
+                continue;
+            }
+
+            if (count(array_filter($rowValues, fn ($value) => $value !== null && $value !== '')) === 0) {
+                continue;
+            }
+
+            $rows[] = $this->mapRow($header, $rowValues);
+        }
+
+        return $rows;
+    }
+
+    private function loadSharedStrings(ZipArchive $zip): array
+    {
+        $sharedStringsXml = $zip->getFromName('xl/sharedStrings.xml');
+        if (!$sharedStringsXml) {
+            return [];
+        }
+
+        $xml = simplexml_load_string($sharedStringsXml);
+        if (!$xml) {
+            return [];
+        }
+
+        $strings = [];
+        foreach ($xml->si as $entry) {
+            $text = '';
+            if (isset($entry->t)) {
+                $text = (string) $entry->t;
+            } elseif (isset($entry->r)) {
+                foreach ($entry->r as $run) {
+                    $text .= (string) $run->t;
+                }
+            }
+            $strings[] = $text;
+        }
+
+        return $strings;
+    }
+
+    private function detectDelimiter($handle): string
+    {
+        $position = ftell($handle);
+        $line = fgets($handle);
+        fseek($handle, $position);
+
+        $delimiters = [',', ';', "\t"];
+        $best = ',';
+        $maxCount = 0;
+
+        foreach ($delimiters as $delimiter) {
+            $count = count(str_getcsv($line ?? '', $delimiter));
+            if ($count > $maxCount) {
+                $maxCount = $count;
+                $best = $delimiter;
+            }
+        }
+
+        return $best;
+    }
+
+    private function normalizeHeaderRow(array $header): array
+    {
+        return array_map(function ($value) {
+            $value = strtolower(trim((string) $value));
+            $value = str_replace([' ', '-'], '_', $value);
+            $value = str_replace(['é', 'è', 'ê', 'ë'], 'e', $value);
+            $value = str_replace(['à', 'â'], 'a', $value);
+            $value = str_replace(['ù', 'û'], 'u', $value);
+            $value = str_replace(['î', 'ï'], 'i', $value);
+            return $value;
+        }, $header);
+    }
+
+    private function mapRow(array $header, array $data): array
+    {
+        $row = [];
+        foreach ($header as $index => $column) {
+            $row[$column] = $data[$index] ?? null;
+        }
+
+        return $row;
+    }
+
+    private function columnIndexFromReference(string $reference): int
+    {
+        preg_match('/([A-Z]+)/', $reference, $matches);
+        $letters = $matches[1] ?? 'A';
+
+        $index = 0;
+        foreach (str_split($letters) as $letter) {
+            $index = $index * 26 + (ord($letter) - 64);
+        }
+
+        return $index - 1;
+    }
+}

--- a/config/jwt.php
+++ b/config/jwt.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'secret' => env('JWT_SECRET', 'change-me'),
+    'ttl' => env('JWT_TTL', 60 * 60 * 24),
+];

--- a/database/migrations/2025_07_10_000000_add_role_to_users_table.php
+++ b/database/migrations/2025_07_10_000000_add_role_to_users_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('role')->default(User::ROLE_SALARIE)->after('is_admin');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('role');
+        });
+    }
+};

--- a/database/migrations/2025_07_10_000001_create_sites_table.php
+++ b/database/migrations/2025_07_10_000001_create_sites_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('sites', function (Blueprint $table) {
+            $table->id();
+            $table->string('site_number')->unique();
+            $table->string('name');
+            $table->string('address');
+            $table->text('comment')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('sites');
+    }
+};

--- a/database/migrations/2025_07_10_000002_create_interventions_table.php
+++ b/database/migrations/2025_07_10_000002_create_interventions_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use App\Models\Intervention;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('interventions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('site_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('status')->default(Intervention::STATUS_EN_ROUTE);
+            $table->boolean('problem_resolved')->default(false);
+            $table->string('unresolved_reason')->nullable();
+            $table->text('comment')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('interventions');
+    }
+};

--- a/database/migrations/2025_07_10_000003_create_media_table.php
+++ b/database/migrations/2025_07_10_000003_create_media_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('media', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('intervention_id')->constrained()->cascadeOnDelete();
+            $table->string('file_path');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('media');
+    }
+};

--- a/routes/console.php
+++ b/routes/console.php
@@ -1,0 +1,7 @@
+<?php
+
+use Illuminate\Support\Facades\Artisan;
+
+Artisan::command('getsirarh:status', function () {
+    $this->comment('GETSIRARH API routes are ready.');
+})->purpose('Check GETSIRARH API status');

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,0 +1,32 @@
+<?php
+
+use App\Http\Controllers\Api\AuthController;
+use App\Http\Controllers\Api\InterventionController;
+use App\Http\Controllers\Api\MediaController;
+use App\Http\Controllers\Api\ReportController;
+use App\Http\Controllers\Api\SiteController;
+use Illuminate\Support\Facades\Route;
+
+Route::prefix('api')->group(function () {
+    Route::post('/auth/login', [AuthController::class, 'login']);
+
+    Route::middleware(['auth.jwt'])->group(function () {
+        Route::get('/auth/me', [AuthController::class, 'me']);
+
+        Route::get('/sites', [SiteController::class, 'index']);
+        Route::get('/sites/{site}', [SiteController::class, 'show']);
+
+        Route::get('/interventions', [InterventionController::class, 'index']);
+        Route::get('/interventions/{intervention}', [InterventionController::class, 'show']);
+        Route::post('/interventions', [InterventionController::class, 'store']);
+        Route::patch('/interventions/{intervention}', [InterventionController::class, 'update']);
+        Route::post('/interventions/{intervention}/media', [MediaController::class, 'store']);
+
+        Route::middleware(['role:ROLE_MANAGER'])->group(function () {
+            Route::post('/sites/import', [SiteController::class, 'import']);
+            Route::get('/reports/weekly', [ReportController::class, 'weekly']);
+            Route::get('/reports/weekly/export.csv', [ReportController::class, 'exportCsv']);
+            Route::get('/reports/weekly/export.pdf', [ReportController::class, 'exportPdf']);
+        });
+    });
+});


### PR DESCRIPTION
### Motivation
- Fournir une API backend pour GETSIRARH qui enregistre et restitue la mémoire du travail terrain pour salariés mobiles et managers. 
- Assurer un contrôle d'accès simple par rôle (`ROLE_SALARIE`, `ROLE_MANAGER`) et authentification JWT pour les usages mobile/web. 
- Permettre l'import obligatoire des sites depuis Excel/CSV et produire des rapports hebdomadaires exploitables en réunion sans solliciter les salariés. 

### Description
- Ajout des modèles et migrations pour `Site`, `Intervention`, `Media` et ajout d'un champ `role` sur `users` pour distinguer les rôles. 
- Implémentation d'un service JWT (`JwtService`) et des middlewares `AuthenticateJwt` et `EnsureRole`, avec enregistrement dans `app/Http/Kernel.php`. 
- Création des contrôleurs API `AuthController`, `SiteController`, `InterventionController`, `MediaController`, `ReportController` et des routes API dans `routes/web.php` pour login, CRUD, import de sites, upload média et exports CSV/PDF de rapports. 
- Ajout du `SpreadsheetImporter` pour parser CSV/XLSX, configuration `config/jwt.php` et une petite commande artisan `getsirarh:status`. 

### Testing
- Aucun test automatisé n'a été exécuté pour cette PR (aucune suite CI lancée).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698367361938832da8935320ca4a9d41)